### PR TITLE
Fix perl version in metainfo

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
   "name" : "Data::Dump",
   "support" : {
   },
-  "perl" : "v6",
+  "perl" : "6.c",
   "provides" : {
     "Data::Dump" : "lib/Data/Dump.pm6"
   },


### PR DESCRIPTION
When building `Data::Dump`, the following warning appears:

```
Please remove leading 'v' from perl version in Data::Dump's meta info.
```

The design docs (https://design.perl6.org/S22.html#perl) say that the
minimal perl version should be used in the "perl" metainfo field, hence
not only was the 'v' removed, the the version was also explicitly set to `6.c`.
This PR thus removes the warning message.

This pull request is submitted in the hope that it is helpful.  Any questions or comments regarding it are more than welcome!
