### PR TITLE
Restructure POD so it can be displayed by perl6

### DIFF
--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -89,109 +89,96 @@ module Data::Dump {
   }
 }
 
-=finish
+=begin pod
 
-=encoding utf8
+=head1 Data::Dump for perl6
 
+that's right folks, here's a quicky for your data dump needs.  if you have
+Term::ANSIColor installed then the output will be so colorful your eyes
+might bleed.
 
-=head1 Data::Dump 
-
-
-=head2 for perl6
-
-that's right folks, here's a quicky for your data dump needs.  if you have Term::ANSIColor installed then the output will be so colorful your eyes might bleed.
-
-feel free to submit bugs or make suggestions, if you submit a bug please provide a concise example that replicates the problem and i'll add some tests and make this thing better.
-
+feel free to submit bugs or make suggestions, if you submit a bug please
+provide a concise example that replicates the problem and i'll add some
+tests and make this thing better.
 
 =head2 options
 
-
-=head3 C<indent>
+=item C<indent>
 
 default: C<2>
 
- perl6
- <...>
- say Dump({ some => object }, :indent(4));
- <...>
+    perl6
+    <...>
+    say Dump({ some => object }, :indent(4));
+    <...>
 
-
-
-=head3 C<max-recursion>
+=item C<max-recursion>
 
 default: C<50>
 
- perl6
- <...>
- say Dump({ some => object }, :max-recursion(3));
- <...>
+    perl6
+    <...>
+    say Dump({ some => object }, :max-recursion(3));
+    <...>
 
-
-
-=head3 C<color>
+=item C<color>
 
 default: C<True>
 
-This will override the default decision to use color on the output if C<Term::ANSIColor> is installed.  Passing a value of C<False> will ensure that the output is vanilla.
+This will override the default decision to use color on the output if
+C<Term::ANSIColor> is installed.  Passing a value of C<False> will ensure
+that the output is vanilla.
 
- perl6
- <...>
- say Dump({ some => object }, :color(False));
- <...>
-
-
+    perl6
+    <...>
+    say Dump({ some => object }, :color(False));
+    <...>
 
 =head2 usage
 
-```perl6
-use Data::Dump;
+    use Data::Dump;
 
-say Dump(%( 
-  key1 => 'value1',
-  key256 => 1,
-));
-```
+    say Dump(%(
+      key1 => 'value1',
+      key256 => 1,
+    ));
 
 output:
- 
- {
-   key1   => "value1".Str,
-   key256 => 1.Int,
- }
 
-note: if you have Term::ANSIColor installed then it's going to be amazing. so, prepare yourself.
+    {
+      key1   => "value1".Str,
+      key256 => 1.Int,
+    }
 
+note: if you have Term::ANSIColor installed then it's going to be amazing.
+so, prepare yourself.
 
 =head2 oh you want to C<Dump> your custom class?
 
 here you go, dude
 
-```perl6
-use Data::Dump;
+    use Data::Dump;
 
-class E {
-  has $.public;
-  has Int $!private = 5;
-  method r(Str $a) { };
-  method s($b, :$named? = 5) { };
-  method e returns Int { say $!private; };
-};
+    class E {
+      has $.public;
+      has Int $!private = 5;
+      method r(Str $a) { };
+      method s($b, :$named? = 5) { };
+      method e returns Int { say $!private; };
+    };
 
-say Dump(E.new);
-```
+    say Dump(E.new);
 
 output:
-```
-E :: (
-  $!private => 5.Int,
-  $!public  => (Any),
 
-  method e () returns Int {...},
-  method public () returns Mu {...},
-  method r (Str $a) returns Mu {...},
-  method s (Any $b, Any :named($named) = 5) returns Mu {...},
-)
-```
+    E :: (
+      $!private => 5.Int,
+      $!public  => (Any),
 
-$=finish
+      method e () returns Int {...},
+      method public () returns Mu {...},
+      method r (Str $a) returns Mu {...},
+      method s (Any $b, Any :named($named) = 5) returns Mu {...},
+    )
+
+=end pod


### PR DESCRIPTION
Issue #8 mentions POD display from the module via `perl6 --doc`.
Unfortunately, this didn't work properly, e.g.

```
perl6 --doc lib/Data/Dump.pm6
```

didn't produce any output.  This commit restructures the POD so that it can
be displayed by the above command and thus should address issue #8.
