### PR TITLE
Correctly check $skip-methods as a falsey value

### DIFF
--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -77,7 +77,7 @@ module Data::Dump {
         }
 
         $out ~= "\n" if @attrs.elems > 0;
-        if $skip-methods {
+        if !$skip-methods {
           for @meths -> $meth {
             my $sig = $meth.signature.params[1..*-2].map({
               .gist.Str.subst(/'{ ... }'/, .default ~~ Callable ?? .default.() !! '');


### PR DESCRIPTION
Was also causing Test 02-obj.t to fail on object dump
