### PR TITLE
Fix test for Pairs with undefined keys

### DIFF
--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -25,8 +25,10 @@ module Data::Dump {
   sub what ($o) {
     return $colorizor("yellow") ~ re-o($o) ~ $colorizor("reset");
   }
-
-  sub Dump ($obj, Int :$indent? = 2, Int :$ilevel? = 0, Bool :$color? = True, Int :$max-recursion? = 50, Bool :$gist = False, Bool :$skip-methods = False) is export {
+  multi Dump (Mu $obj,  Int :$indent? = 2, Int :$ilevel? = 0, Bool :$color? = True, Int :$max-recursion? = 50, Bool :$gist = False, Bool :$skip-methods = False) is export {
+    return $obj.gist;
+  }
+  multi Dump (Any $obj, Int :$indent? = 2, Int :$ilevel? = 0, Bool :$color? = True, Int :$max-recursion? = 50, Bool :$gist = False, Bool :$skip-methods = False) is export {
     return '...' if $max-recursion == $ilevel;
     temp $colorizor = sub (Str $s) { '' } unless $color;
     try {

--- a/t/02-obj.t
+++ b/t/02-obj.t
@@ -3,7 +3,7 @@
 use Test;
 use Data::Dump;
 
-plan 1;
+plan 3;
 
 class E {
   has $.public;
@@ -19,5 +19,8 @@ my $out = Dump(E.new, :color(False));
 my $expected = "E :: (\n  \$!private => 5.Int,\n  \$!public => (Any),\n\n  method e () returns Int \{...},\n  method public () returns Mu \{...},\n  method r (Str \$a) returns Mu \{...},\n  method s (\$b, :\$named = 5) returns Mu \{...},\n)";
 
 ok $out eq $expected, "got expected data structure" or die $out;
+
+is Dump(Mu), '(Mu)', 'Can dump an undefined Mu type object';
+is Dump(Any), '(Any)', 'Can dump an undefined Any type object';;
 
 # vi:syntax=perl6

--- a/t/04-gist.t
+++ b/t/04-gist.t
@@ -15,6 +15,6 @@ $out = Dump('foobar' ~~ m/foo(bar)/, :color(False), :gist);
 
 ok $out eq "Match :: (\n  ｢foobar｣\n 0 => ｢bar｣,\n)", 'Match object';
 
-$out = Dump(Pair.new, :color(False), :gist);
+$out = Dump(Pair.new(Mu, Mu), :color(False), :gist);
 
-ok $out eq "Pair :: (\n  (Mu) => (Mu),\n)";
+is-deeply $out, "Pair :: (\n  (Mu) => (Mu),\n)", "Pair with undefined keys";


### PR DESCRIPTION
* In rakudo blead you can no longer call Pair.new without any arguments,
  so specify Mu manually.

*Add ability to Dump a Mu type object
  * Before binding would fail if you tried to Dump(Mu). The multi is needed
    because if we just set sub Dump to accept Mu objects, it will
    Dump `(Any)` erroneously for `(Mu)` type objects.