### PR TITLE
Pass tests with future Rakudo v2020.08

### DIFF
--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -112,9 +112,7 @@ module Data::Dump {
         $out ~= "{$spac2}{$obj.gist},\n";
       } else {
         my @attrs    = try { $obj.^attributes.sort({ $^x.Str cmp $^y.Str }) } // @();
-        my @meths    = try { $obj.^methods.grep({
-          $obj ~~ $_.^mro[0];
-        }).sort({ $^x.gist.Str cmp $^y.gist.Str }) } // @();
+        my @meths    = try { $obj.^methods(:local).sort({ $^x.gist.Str cmp $^y.gist.Str }) } // @();
         my @attr-len = @attrs.map({ next unless .so && .^can('Str'); .Str.chars });
         my @meth-len = @meths.map({ next unless .^can('gist'); .gist.Str.chars });
         my $spacing  = (@attr-len, @meth-len).max;

--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -54,7 +54,7 @@ module Data::Dump {
     %overrides.map({ %overrides{$_.key.^name} //= $_.value; });
     if %overrides{$obj.^name}.defined {
       my %options;
-      warn 'Overrides must contain only one positional parameter' if %overrides{$obj.^name}.signature.params.grep(!*.named).elems != 1;
+      warn 'Overrides must contain only one positional parameter' if %overrides{$obj.^name}.signature.params.grep(*.positional).elems != 1;
       for %overrides{$obj.^name}.signature.params -> $param {
         next unless $param.named;
         next unless $param.named ~~ (qw<$indent $ilevel $color $max-recursion $gist $skip-methods $no-postfix %overrides>);
@@ -135,7 +135,7 @@ module Data::Dump {
             next if %parent-methods{$meth.gist.Str};
             if %overrides{Method.^name} {
               my %options;
-              warn 'Overrides must contain only one positional parameter' if %overrides{Method.^name}.signature.params.grep(!*.named).elems != 1;
+              warn 'Overrides must contain only one positional parameter' if %overrides{Method.^name}.signature.params.grep(*.positional).elems != 1;
               for %overrides{Method.^name}.signature.params -> $param {
                 next unless $param.named;
                 next unless $param.named ~~ (qw<$indent $ilevel $color $max-recursion $gist $skip-methods $no-postfix %overrides>);

--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -30,8 +30,8 @@ module Data::Dump {
         %provides-cache{$x.^name}.map({ %r{$_}.push($x.^name); });
       } else {
         $x.^methods.map({
-          %provides-cache{$x.^name}.push($_.gist.Str);
-          %r{$_.gist.Str}.push($x.^name);
+          %provides-cache{$x.^name}.push($_.name.Str);
+          %r{$_.name.Str}.push($x.^name);
         });
       }
     }
@@ -112,9 +112,9 @@ module Data::Dump {
         $out ~= "{$spac2}{$obj.gist},\n";
       } else {
         my @attrs    = try { $obj.^attributes.sort({ $^x.Str cmp $^y.Str }) } // @();
-        my @meths    = try { $obj.^methods(:local).sort({ $^x.gist.Str cmp $^y.gist.Str }) } // @();
+        my @meths    = try { $obj.^methods(:local).sort({ $^x.name.Str cmp $^y.name.Str }) } // @();
         my @attr-len = @attrs.map({ next unless .so && .^can('Str'); .Str.chars });
-        my @meth-len = @meths.map({ next unless .^can('gist'); .gist.Str.chars });
+        my @meth-len = @meths.map({ .name.Str.chars });
         my $spacing  = (@attr-len, @meth-len).max;
 
 
@@ -129,8 +129,8 @@ module Data::Dump {
         $out ~= "\n" if @attrs.elems > 0;
         if !$skip-methods {
           my %parent-methods = pseudo-cache($obj);
-          for @meths.sort({$^a.gist.Str cmp $^b.gist.Str}) -> $meth {
-            next if %parent-methods{$meth.gist.Str};
+          for @meths -> $meth {
+            next if %parent-methods{$meth.name.Str};
             if %overrides{Method.^name} {
               my %options;
               warn 'Overrides must contain only one positional parameter' if %overrides{Method.^name}.signature.params.grep(*.positional).elems != 1;
@@ -145,9 +145,9 @@ module Data::Dump {
                 my $sig = $meth.signature.params[1..*-2].map({
                   .gist.Str.subst(/'{ ... }'/, do with .default { .() } else { '' });
                 }).join(sym(', ') ~ $colorizor('blue'));
-                $out ~= "{$spac2}{sym('method')} {key($meth.gist.Str)} ({val($sig)}) returns {what($meth.returns.WHAT.^name)} {sym('{...}')},\n";
+                $out ~= "{$spac2}{sym('method')} {key($meth.name.Str)} ({val($sig)}) returns {what($meth.returns.WHAT.^name)} {sym('{...}')},\n";
               } else {
-                CATCH { $out ~= "{$spac2}{sym('method')} {key($meth.gist.Str)},\n"; };
+                CATCH { $out ~= "{$spac2}{sym('method')} {key($meth.name.Str)},\n"; };
               }
             }
           }

--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -144,13 +144,9 @@ module Data::Dump {
               $out ~= $spac2 ~ %overrides{Method.^name}($meth, |%options) ~ "\n";
             } else {
               if $meth.^can('signature') {
-                my $sig = '';
-                try { 
-                  CATCH { default { } }
-                  $sig = $meth.signature.params[1..*-2].map({
-                    .gist.Str.subst(/'{ ... }'/, do with .default { .() } else { '' });
-                  }).join(sym(', ') ~ $colorizor('blue'));
-                };
+                my $sig = $meth.signature.params[1..*-2].map({
+                  .gist.Str.subst(/'{ ... }'/, do with .default { .() } else { '' });
+                }).join(sym(', ') ~ $colorizor('blue'));
                 $out ~= "{$spac2}{sym('method')} {key($meth.gist.Str)} ({val($sig)}) returns {what($meth.returns.WHAT.^name)} {sym('{...}')},\n";
               } else {
                 CATCH { $out ~= "{$spac2}{sym('method')} {key($meth.gist.Str)},\n"; };

--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -57,7 +57,7 @@ module Data::Dump {
       warn 'Overrides must contain only one positional parameter' if %overrides{$obj.^name}.signature.params.grep(*.positional).elems != 1;
       for %overrides{$obj.^name}.signature.params -> $param {
         next unless $param.named;
-        next unless $param.named ~~ (qw<$indent $ilevel $color $max-recursion $gist $skip-methods $no-postfix %overrides>);
+        next unless $param.name ~~ (qw<$indent $ilevel $color $max-recursion $gist $skip-methods $no-postfix %overrides>);
         %options{$param.substr(1)} = $::($param.substr(1));
       }
       $out ~= %overrides{$obj.^name}($obj, |%options) ~ "\n";
@@ -138,7 +138,7 @@ module Data::Dump {
               warn 'Overrides must contain only one positional parameter' if %overrides{Method.^name}.signature.params.grep(*.positional).elems != 1;
               for %overrides{Method.^name}.signature.params -> $param {
                 next unless $param.named;
-                next unless $param.named ~~ (qw<$indent $ilevel $color $max-recursion $gist $skip-methods $no-postfix %overrides>);
+                next unless $param.name ~~ (qw<$indent $ilevel $color $max-recursion $gist $skip-methods $no-postfix %overrides>);
                 %options{$param.substr(1)} = $::($param.substr(1));
               }
               $out ~= $spac2 ~ %overrides{Method.^name}($meth, |%options) ~ "\n";

--- a/lib/Data/Dump.pm6
+++ b/lib/Data/Dump.pm6
@@ -148,7 +148,7 @@ module Data::Dump {
                 try { 
                   CATCH { default { } }
                   $sig = $meth.signature.params[1..*-2].map({
-                    .gist.Str.subst(/'{ ... }'/, .default ~~ Callable ?? .default.() !! '');
+                    .gist.Str.subst(/'{ ... }'/, do with .default { .() } else { '' });
                   }).join(sym(', ') ~ $colorizor('blue'));
                 };
                 $out ~= "{$spac2}{sym('method')} {key($meth.gist.Str)} ({val($sig)}) returns {what($meth.returns.WHAT.^name)} {sym('{...}')},\n";


### PR DESCRIPTION
`Data::Dump` has test failures in the [Blin run](https://github.com/rakudo/rakudo/issues/3850) for Rakudo v2020.08. This is due to a combination of a breaking change in `Parameter.default` and some other minor issues with `Parameter` and `Method` handling. The changes in this PR allow tests to pass again and should be compatible with older and newer releases of Rakudo.